### PR TITLE
Fix watch falsely reporting server started when port is occupied

### DIFF
--- a/src/foliate/cli.py
+++ b/src/foliate/cli.py
@@ -122,10 +122,13 @@ def build(force: bool, verbose: bool, serve: bool, port: int):
         from .resources import start_dev_server
 
         build_dir = config.get_build_dir()
-        click.echo(f"\nStarting server at http://localhost:{port}")
-        click.echo("Press Ctrl+C to stop")
         try:
+            click.echo(f"\nStarting server at http://localhost:{port}")
+            click.echo("Press Ctrl+C to stop")
             start_dev_server(build_dir, port, background=False)
+        except OSError as e:
+            click.echo(f"\nError: {e}", err=True)
+            raise SystemExit(1)
         except KeyboardInterrupt:
             click.echo("\nServer stopped")
 

--- a/src/foliate/watch.py
+++ b/src/foliate/watch.py
@@ -134,10 +134,16 @@ def watch(config: Config, port: int = 8000, verbose: bool = False) -> None:
     from .resources import start_dev_server
 
     build_dir = config.get_build_dir()
-    server_process = start_dev_server(build_dir, port, background=True)
+    server_process = None
+    try:
+        server_process = start_dev_server(build_dir, port, background=True)
+        info("=" * 60)
+        info(f"Server started: http://localhost:{port}")
+    except OSError as e:
+        error(f"Could not start server: {e}")
+        info("=" * 60)
+        info("Continuing in watch-only mode (no server)")
 
-    info("=" * 60)
-    info(f"Server started: http://localhost:{port}")
     info("Watching for changes... (Press Ctrl+C to stop)")
     info("=" * 60)
 

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -545,6 +545,27 @@ class TestWatchFunction:
             # Should still stop observer without error
             mock_observer.stop.assert_called_once()
 
+    def test_watch_continues_when_port_occupied(self, config):
+        """Watch should continue in watch-only mode when port is occupied."""
+        with (
+            patch("foliate.watch.do_build"),
+            patch("foliate.resources.start_dev_server") as mock_server,
+            patch("foliate.watch.Observer") as mock_observer_class,
+            patch("foliate.watch.time.sleep") as mock_sleep,
+        ):
+            mock_observer = MagicMock()
+            mock_observer_class.return_value = mock_observer
+            mock_server.side_effect = OSError("Port 8000 is already in use")
+
+            mock_sleep.side_effect = KeyboardInterrupt()
+
+            # Should not raise - watch continues without server
+            watch(config)
+
+            # Observer should still be set up and started
+            mock_observer.schedule.assert_called()
+            mock_observer.stop.assert_called_once()
+
 
 class TestRebuildCallback:
     """Tests for the rebuild callback created in watch()."""

--- a/uv.lock
+++ b/uv.lock
@@ -124,7 +124,7 @@ wheels = [
 
 [[package]]
 name = "foliate"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Check port availability before launching the dev server and verify the
subprocess stays alive after spawning. When the port is in use, watch
mode now prints an error and continues in watch-only mode, and build
--serve exits with an error.

Closes #12

https://claude.ai/code/session_01DdcPjBvLt4gx3jjmHueM5r