### PR TITLE
Document home_page config option in default template

### DIFF
--- a/src/foliate/defaults/config.toml
+++ b/src/foliate/defaults/config.toml
@@ -35,6 +35,10 @@ homepage_dir = "_homepage"
 # Set to empty string "" to deploy wiki content at root
 wiki_prefix = "wiki"
 
+# Wiki home page - used as the redirect target for /wiki/ and for recent pages list
+# Visiting /wiki/ will redirect to /wiki/{home_page}/
+home_page = "Home"
+
 # Enable incremental builds (only rebuild changed files)
 incremental = true
 

--- a/uv.lock
+++ b/uv.lock
@@ -124,7 +124,7 @@ wheels = [
 
 [[package]]
 name = "foliate"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Closes #10

The wiki root redirect (from /wiki/ to /wiki/Home/) was already
implemented but the home_page config option was missing from the
default config template, making it hard to discover and customize.

https://claude.ai/code/session_018XLPGFdrViDa8cztrVzLCu