### PR TITLE
Add `foliate status` command to preview build changes

### DIFF
--- a/src/foliate/cli.py
+++ b/src/foliate/cli.py
@@ -191,6 +191,26 @@ def doctor():
 
 
 @main.command()
+@click.option("--verbose", "-v", is_flag=True, help="Show all pages including unchanged")
+def status(verbose: bool):
+    """Show which pages would be built or deployed."""
+    from .logging import setup_logging
+    from .status import format_status_report, scan_status
+
+    setup_logging(verbose=False)
+
+    try:
+        config = Config.find_and_load()
+    except FileNotFoundError as e:
+        click.echo(f"Error: {e}", err=True)
+        raise SystemExit(1)
+
+    report = scan_status(config)
+    output = format_status_report(report, verbose=verbose)
+    click.echo(output)
+
+
+@main.command()
 @click.option(
     "--dry-run", "-n", is_flag=True, help="Show what would be done without executing"
 )

--- a/src/foliate/status.py
+++ b/src/foliate/status.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from .build import get_content_info, is_path_ignored
-from .cache import BUILD_CACHE_FILE, load_build_cache
+from .cache import BUILD_CACHE_FILE, check_global_deps_changed, load_build_cache
 from .config import Config
 from .markdown_utils import parse_markdown_file
 
@@ -43,7 +43,7 @@ class StatusReport:
 
     @property
     def published_pages(self) -> list[PageStatus]:
-        return [p for p in self.pages if p.published]
+        return [p for p in self.pages if p.public and p.published]
 
     @property
     def private_pages(self) -> list[PageStatus]:
@@ -69,6 +69,7 @@ def _get_page_state(
     build_dir: Path,
     wiki_dir_name: str,
     build_cache: dict,
+    force_rebuild_all: bool,
 ) -> str:
     """Determine whether a page is new, modified, or unchanged.
 
@@ -83,6 +84,10 @@ def _get_page_state(
 
     if not output_file.exists():
         return "new"
+
+    # A global invalidation means existing pages will still rebuild.
+    if force_rebuild_all:
+        return "modified"
 
     # Check cache for modification
     cache_key = str(md_file)
@@ -114,6 +119,13 @@ def scan_status(config: Config) -> StatusReport:
     build_dir = config.get_build_dir()
     cache_file = config.get_cache_dir() / BUILD_CACHE_FILE
     build_cache = load_build_cache(cache_file)
+    force_rebuild_all = not config.build.incremental
+    if (
+        not force_rebuild_all
+        and config.config_path
+        and check_global_deps_changed(build_cache, config.config_path, vault_path)
+    ):
+        force_rebuild_all = True
 
     pages: list[PageStatus] = []
 
@@ -140,7 +152,13 @@ def scan_status(config: Config) -> StatusReport:
 
         if is_public:
             state = _get_page_state(
-                md_file, page_path, content_base_url, build_dir, wiki_dir_name, build_cache
+                md_file,
+                page_path,
+                content_base_url,
+                build_dir,
+                wiki_dir_name,
+                build_cache,
+                force_rebuild_all,
             )
         else:
             state = "unchanged"  # not relevant for private pages

--- a/src/foliate/status.py
+++ b/src/foliate/status.py
@@ -1,0 +1,213 @@
+"""Page status reporting for foliate.
+
+Scans the vault and reports which pages would be built, deployed,
+and whether they are new, modified, or unchanged since the last build.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .build import get_content_info, is_path_ignored
+from .cache import BUILD_CACHE_FILE, load_build_cache
+from .config import Config
+from .markdown_utils import parse_markdown_file
+
+
+@dataclass
+class PageStatus:
+    """Status of a single page in the vault."""
+
+    page_path: str
+    source_file: Path
+    base_url: str
+    is_homepage_content: bool
+    public: bool
+    published: bool
+    state: str  # "new", "modified", "unchanged"
+
+    @property
+    def output_url(self) -> str:
+        """The URL this page will be served at."""
+        return f"{self.base_url}{self.page_path}/"
+
+
+@dataclass
+class StatusReport:
+    """Summary of all page statuses in the vault."""
+
+    pages: list[PageStatus]
+
+    @property
+    def public_pages(self) -> list[PageStatus]:
+        return [p for p in self.pages if p.public]
+
+    @property
+    def published_pages(self) -> list[PageStatus]:
+        return [p for p in self.pages if p.published]
+
+    @property
+    def private_pages(self) -> list[PageStatus]:
+        return [p for p in self.pages if not p.public]
+
+    @property
+    def new_pages(self) -> list[PageStatus]:
+        return [p for p in self.pages if p.public and p.state == "new"]
+
+    @property
+    def modified_pages(self) -> list[PageStatus]:
+        return [p for p in self.pages if p.public and p.state == "modified"]
+
+    @property
+    def unchanged_pages(self) -> list[PageStatus]:
+        return [p for p in self.pages if p.public and p.state == "unchanged"]
+
+
+def _get_page_state(
+    md_file: Path,
+    page_path: str,
+    base_url: str,
+    build_dir: Path,
+    wiki_dir_name: str,
+    build_cache: dict,
+) -> str:
+    """Determine whether a page is new, modified, or unchanged.
+
+    Returns:
+        "new", "modified", or "unchanged"
+    """
+    # Determine expected output file
+    if base_url == "/":
+        output_file = build_dir / page_path / "index.html"
+    else:
+        output_file = build_dir / wiki_dir_name / page_path / "index.html"
+
+    if not output_file.exists():
+        return "new"
+
+    # Check cache for modification
+    cache_key = str(md_file)
+    md_mtime = md_file.stat().st_mtime
+    if cache_key in build_cache and build_cache[cache_key] >= md_mtime:
+        return "unchanged"
+
+    return "modified"
+
+
+def scan_status(config: Config) -> StatusReport:
+    """Scan the vault and produce a status report of all pages.
+
+    Args:
+        config: The foliate configuration
+
+    Returns:
+        StatusReport with the status of every markdown file
+    """
+    vault_path = config.vault_path
+    if not vault_path or not vault_path.exists():
+        return StatusReport(pages=[])
+
+    ignored_folders = config.build.ignored_folders
+    homepage_dir = config.build.homepage_dir
+    wiki_base_url = config.base_urls["wiki"]
+    wiki_dir_name = config.build.wiki_prefix.strip("/")
+
+    build_dir = config.get_build_dir()
+    cache_file = config.get_cache_dir() / BUILD_CACHE_FILE
+    build_cache = load_build_cache(cache_file)
+
+    pages: list[PageStatus] = []
+
+    for md_file in sorted(vault_path.glob("**/*.md")):
+        if is_path_ignored(md_file, vault_path, ignored_folders):
+            continue
+
+        # Skip files inside .foliate/
+        try:
+            rel_path = md_file.relative_to(vault_path)
+            if rel_path.parts and rel_path.parts[0] == ".foliate":
+                continue
+        except ValueError:
+            continue
+
+        page_path = rel_path.with_suffix("").as_posix()
+        page_path, content_base_url, is_homepage = get_content_info(
+            page_path, homepage_dir, wiki_base_url
+        )
+
+        meta, _ = parse_markdown_file(md_file)
+        is_public = meta.get("public", False)
+        is_published = meta.get("published", False)
+
+        if is_public:
+            state = _get_page_state(
+                md_file, page_path, content_base_url, build_dir, wiki_dir_name, build_cache
+            )
+        else:
+            state = "unchanged"  # not relevant for private pages
+
+        pages.append(
+            PageStatus(
+                page_path=page_path,
+                source_file=md_file,
+                base_url=content_base_url,
+                is_homepage_content=is_homepage,
+                public=is_public,
+                published=is_published,
+                state=state,
+            )
+        )
+
+    return StatusReport(pages=pages)
+
+
+def format_status_report(report: StatusReport, verbose: bool = False) -> str:
+    """Format a status report for display.
+
+    Args:
+        report: The status report to format
+        verbose: If True, list all pages including unchanged ones
+
+    Returns:
+        Formatted string for terminal output
+    """
+    lines: list[str] = []
+
+    new = report.new_pages
+    modified = report.modified_pages
+    unchanged = report.unchanged_pages
+    private = report.private_pages
+
+    if new:
+        lines.append(f"New pages ({len(new)}):")
+        for p in new:
+            pub = " [published]" if p.published else ""
+            lines.append(f"  + {p.page_path}{pub}")
+        lines.append("")
+
+    if modified:
+        lines.append(f"Modified pages ({len(modified)}):")
+        for p in modified:
+            pub = " [published]" if p.published else ""
+            lines.append(f"  ~ {p.page_path}{pub}")
+        lines.append("")
+
+    if verbose and unchanged:
+        lines.append(f"Unchanged pages ({len(unchanged)}):")
+        for p in unchanged:
+            pub = " [published]" if p.published else ""
+            lines.append(f"    {p.page_path}{pub}")
+        lines.append("")
+
+    # Summary line
+    total_public = len(report.public_pages)
+    total_published = len(report.published_pages)
+    summary_parts = [
+        f"{total_public} public",
+        f"{total_published} published",
+        f"{len(new)} new",
+        f"{len(modified)} modified",
+        f"{len(private)} private",
+    ]
+    lines.append("Summary: " + ", ".join(summary_parts))
+
+    return "\n".join(lines)

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,293 @@
+"""Tests for foliate status module."""
+
+from foliate.config import Config
+from foliate.status import PageStatus, StatusReport, format_status_report, scan_status
+
+
+def _make_vault(tmp_path, pages: dict[str, dict]) -> Config:
+    """Create a vault with pages and return a Config.
+
+    Args:
+        tmp_path: pytest tmp_path fixture
+        pages: dict mapping relative file paths (e.g. "test.md") to dicts
+               with keys: content (str), and optionally a subdir like "_homepage/about.md"
+    """
+    vault_path = tmp_path / "vault"
+    vault_path.mkdir()
+
+    foliate_dir = vault_path / ".foliate"
+    foliate_dir.mkdir()
+    config_path = foliate_dir / "config.toml"
+    config_path.write_text(
+        """
+[site]
+name = "Test Site"
+url = "https://test.com"
+
+[build]
+home_redirect = "about"
+"""
+    )
+
+    for rel_path, info in pages.items():
+        md_file = vault_path / rel_path
+        md_file.parent.mkdir(parents=True, exist_ok=True)
+        md_file.write_text(info["content"])
+
+    return Config.load(config_path)
+
+
+class TestScanStatus:
+    """Tests for scan_status()."""
+
+    def test_empty_vault(self, tmp_path):
+        """Empty vault returns empty report."""
+        config = _make_vault(tmp_path, {})
+        report = scan_status(config)
+        assert len(report.pages) == 0
+
+    def test_private_page(self, tmp_path):
+        """Page without public: true is private."""
+        config = _make_vault(
+            tmp_path,
+            {
+                "note.md": {
+                    "content": "---\ntitle: Note\n---\nPrivate note.\n",
+                },
+            },
+        )
+        report = scan_status(config)
+        assert len(report.pages) == 1
+        assert report.pages[0].public is False
+        assert len(report.private_pages) == 1
+
+    def test_public_page_is_new_before_build(self, tmp_path):
+        """Public page shows as 'new' when no build output exists."""
+        config = _make_vault(
+            tmp_path,
+            {
+                "test.md": {
+                    "content": "---\ntitle: Test\npublic: true\n---\nHello.\n",
+                },
+            },
+        )
+        report = scan_status(config)
+        assert len(report.public_pages) == 1
+        assert report.public_pages[0].state == "new"
+        assert len(report.new_pages) == 1
+
+    def test_published_page_detected(self, tmp_path):
+        """Published pages are reported correctly."""
+        config = _make_vault(
+            tmp_path,
+            {
+                "blog.md": {
+                    "content": "---\ntitle: Blog\npublic: true\npublished: true\n---\nPost.\n",
+                },
+            },
+        )
+        report = scan_status(config)
+        assert len(report.published_pages) == 1
+        assert report.published_pages[0].published is True
+
+    def test_homepage_content(self, tmp_path):
+        """Homepage content is identified correctly."""
+        config = _make_vault(
+            tmp_path,
+            {
+                "_homepage/about.md": {
+                    "content": "---\ntitle: About\npublic: true\n---\nAbout page.\n",
+                },
+            },
+        )
+        report = scan_status(config)
+        assert len(report.pages) == 1
+        p = report.pages[0]
+        assert p.is_homepage_content is True
+        assert p.base_url == "/"
+        assert p.page_path == "about"
+
+    def test_unchanged_after_build(self, tmp_path):
+        """Page shows as 'unchanged' after a successful build."""
+        from foliate.build import build
+
+        config = _make_vault(
+            tmp_path,
+            {
+                "test.md": {
+                    "content": "---\ntitle: Test\npublic: true\n---\nHello.\n",
+                },
+            },
+        )
+        build(config=config, force_rebuild=True)
+
+        report = scan_status(config)
+        assert len(report.public_pages) == 1
+        assert report.public_pages[0].state == "unchanged"
+        assert len(report.unchanged_pages) == 1
+
+    def test_modified_after_edit(self, tmp_path):
+        """Page shows as 'modified' when source is newer than cache."""
+        import time
+
+        from foliate.build import build
+
+        config = _make_vault(
+            tmp_path,
+            {
+                "test.md": {
+                    "content": "---\ntitle: Test\npublic: true\n---\nHello.\n",
+                },
+            },
+        )
+        build(config=config, force_rebuild=True)
+
+        # Edit the file (ensure mtime changes)
+        time.sleep(0.05)
+        md_file = config.vault_path / "test.md"
+        md_file.write_text("---\ntitle: Test\npublic: true\n---\nUpdated.\n")
+
+        report = scan_status(config)
+        assert len(report.modified_pages) == 1
+        assert report.modified_pages[0].state == "modified"
+
+    def test_ignored_folders_excluded(self, tmp_path):
+        """Pages in ignored folders are not included."""
+        vault_path = tmp_path / "vault"
+        vault_path.mkdir()
+
+        foliate_dir = vault_path / ".foliate"
+        foliate_dir.mkdir()
+        config_path = foliate_dir / "config.toml"
+        config_path.write_text(
+            """
+[site]
+name = "Test"
+
+[build]
+ignored_folders = ["_private"]
+home_redirect = "about"
+"""
+        )
+
+        private_dir = vault_path / "_private"
+        private_dir.mkdir()
+        (private_dir / "secret.md").write_text(
+            "---\ntitle: Secret\npublic: true\n---\nSecret.\n"
+        )
+
+        config = Config.load(config_path)
+        report = scan_status(config)
+        assert len(report.pages) == 0
+
+    def test_mixed_pages(self, tmp_path):
+        """Mix of public, published, and private pages."""
+        config = _make_vault(
+            tmp_path,
+            {
+                "public-only.md": {
+                    "content": "---\ntitle: Public\npublic: true\n---\nPublic.\n",
+                },
+                "published.md": {
+                    "content": "---\ntitle: Published\npublic: true\npublished: true\n---\nPublished.\n",
+                },
+                "private.md": {
+                    "content": "---\ntitle: Private\n---\nPrivate.\n",
+                },
+            },
+        )
+        report = scan_status(config)
+        assert len(report.pages) == 3
+        assert len(report.public_pages) == 2
+        assert len(report.published_pages) == 1
+        assert len(report.private_pages) == 1
+        assert len(report.new_pages) == 2
+
+
+class TestPageStatus:
+    """Tests for PageStatus dataclass."""
+
+    def test_output_url_wiki(self):
+        """Wiki pages have /wiki/ prefix in URL."""
+        ps = PageStatus(
+            page_path="Notes/Ideas",
+            source_file=None,
+            base_url="/wiki/",
+            is_homepage_content=False,
+            public=True,
+            published=False,
+            state="new",
+        )
+        assert ps.output_url == "/wiki/Notes/Ideas/"
+
+    def test_output_url_homepage(self):
+        """Homepage pages have / prefix in URL."""
+        ps = PageStatus(
+            page_path="about",
+            source_file=None,
+            base_url="/",
+            is_homepage_content=True,
+            public=True,
+            published=False,
+            state="new",
+        )
+        assert ps.output_url == "/about/"
+
+
+class TestFormatStatusReport:
+    """Tests for format_status_report()."""
+
+    def test_empty_report(self):
+        """Empty report shows zeroes."""
+        report = StatusReport(pages=[])
+        output = format_status_report(report)
+        assert "0 public" in output
+        assert "0 new" in output
+
+    def test_new_pages_shown(self):
+        """New pages appear with + prefix."""
+        pages = [
+            PageStatus("test", None, "/wiki/", False, True, False, "new"),
+        ]
+        report = StatusReport(pages=pages)
+        output = format_status_report(report)
+        assert "+ test" in output
+        assert "1 new" in output
+
+    def test_modified_pages_shown(self):
+        """Modified pages appear with ~ prefix."""
+        pages = [
+            PageStatus("test", None, "/wiki/", False, True, False, "modified"),
+        ]
+        report = StatusReport(pages=pages)
+        output = format_status_report(report)
+        assert "~ test" in output
+        assert "1 modified" in output
+
+    def test_unchanged_hidden_without_verbose(self):
+        """Unchanged pages are hidden by default."""
+        pages = [
+            PageStatus("test", None, "/wiki/", False, True, False, "unchanged"),
+        ]
+        report = StatusReport(pages=pages)
+        output = format_status_report(report, verbose=False)
+        assert "Unchanged" not in output
+
+    def test_unchanged_shown_with_verbose(self):
+        """Unchanged pages are shown with --verbose."""
+        pages = [
+            PageStatus("test", None, "/wiki/", False, True, False, "unchanged"),
+        ]
+        report = StatusReport(pages=pages)
+        output = format_status_report(report, verbose=True)
+        assert "Unchanged" in output
+        assert "test" in output
+
+    def test_published_tag_shown(self):
+        """Published pages get [published] tag."""
+        pages = [
+            PageStatus("blog", None, "/wiki/", False, True, True, "new"),
+        ]
+        report = StatusReport(pages=pages)
+        output = format_status_report(report)
+        assert "[published]" in output

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -203,6 +203,80 @@ home_redirect = "about"
         assert len(report.private_pages) == 1
         assert len(report.new_pages) == 2
 
+    def test_global_config_change_marks_pages_modified(self, tmp_path):
+        """Config mtime changes should mark existing pages as modified."""
+        import time
+
+        from foliate.build import build
+
+        config = _make_vault(
+            tmp_path,
+            {
+                "test.md": {
+                    "content": "---\ntitle: Test\npublic: true\n---\nHello.\n",
+                },
+            },
+        )
+        build(config=config, force_rebuild=True)
+
+        # Ensure config mtime increases after cache snapshot.
+        time.sleep(0.05)
+        assert config.config_path is not None
+        config.config_path.write_text(config.config_path.read_text() + "\n# updated\n")
+
+        report = scan_status(config)
+        assert report.public_pages[0].state == "modified"
+        assert len(report.modified_pages) == 1
+
+    def test_incremental_disabled_marks_existing_pages_modified(self, tmp_path):
+        """With incremental=false, existing pages should be reported as rebuilt."""
+        from foliate.build import build
+
+        vault_path = tmp_path / "vault"
+        vault_path.mkdir()
+        foliate_dir = vault_path / ".foliate"
+        foliate_dir.mkdir()
+        config_path = foliate_dir / "config.toml"
+        config_path.write_text(
+            """
+[site]
+name = "Test Site"
+url = "https://test.com"
+
+[build]
+home_redirect = "about"
+incremental = false
+"""
+        )
+        (vault_path / "test.md").write_text(
+            "---\ntitle: Test\npublic: true\n---\nHello.\n"
+        )
+
+        config = Config.load(config_path)
+        build(config=config, force_rebuild=True)
+
+        report = scan_status(config)
+        assert report.public_pages[0].state == "modified"
+        assert len(report.modified_pages) == 1
+
+    def test_private_published_page_not_counted_as_published(self, tmp_path):
+        """Private pages should never count toward published totals."""
+        config = _make_vault(
+            tmp_path,
+            {
+                "public.md": {
+                    "content": "---\ntitle: Public\npublic: true\npublished: true\n---\nPublic.\n",
+                },
+                "private.md": {
+                    "content": "---\ntitle: Private\npublished: true\n---\nPrivate.\n",
+                },
+            },
+        )
+        report = scan_status(config)
+        assert len(report.public_pages) == 1
+        assert len(report.published_pages) == 1
+        assert report.published_pages[0].page_path == "public"
+
 
 class TestPageStatus:
     """Tests for PageStatus dataclass."""
@@ -291,3 +365,13 @@ class TestFormatStatusReport:
         report = StatusReport(pages=pages)
         output = format_status_report(report)
         assert "[published]" in output
+
+    def test_summary_counts_only_public_published_pages(self):
+        """Summary should ignore private pages even if published=true."""
+        pages = [
+            PageStatus("public", None, "/wiki/", False, True, True, "new"),
+            PageStatus("private", None, "/wiki/", False, False, True, "unchanged"),
+        ]
+        report = StatusReport(pages=pages)
+        output = format_status_report(report)
+        assert "1 published" in output

--- a/uv.lock
+++ b/uv.lock
@@ -124,7 +124,7 @@ wheels = [
 
 [[package]]
 name = "foliate"
-version = "0.4.4"
+version = "0.4.5"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Introduces a new `status` command that scans the vault and reports which
pages would be built or deployed, categorizing them as new, modified, or
unchanged. This lets users preview what a build will do before running it.

- New status.py module with scan_status() and format_status_report()
- CLI command with --verbose flag to show unchanged pages
- 17 tests covering scanning, formatting, and edge cases

https://claude.ai/code/session_01DjjM2Q7VXQGEcHJehJo2md