### PR TITLE
Bootstrap dev dependencies for local CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: build clean test ci publish
+.PHONY: build clean sync-dev test ci publish
+
+sync-dev:
+	uv sync --frozen --extra dev
 
 build: clean
 	uv build
@@ -6,10 +9,10 @@ build: clean
 clean:
 	rm -rf dist/*.whl dist/*.tar.gz
 
-test:
+test: sync-dev
 	uv run pytest
 
-ci:
+ci: sync-dev
 	uv run mypy src/foliate
 	uv run pytest -q
 	uv build

--- a/tests/test_makefile.py
+++ b/tests/test_makefile.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def test_makefile_bootstraps_dev_dependencies_for_test_targets():
+    makefile = (Path(__file__).resolve().parents[1] / "Makefile").read_text()
+
+    assert "sync-dev:\n\tuv sync --frozen --extra dev\n" in makefile
+    assert "\ntest: sync-dev\n\tuv run pytest\n" in makefile
+    assert "\nci: sync-dev\n\tuv run mypy src/foliate\n\tuv run pytest -q\n\tuv build\n" in makefile


### PR DESCRIPTION
## Summary
- add a `sync-dev` Make target that runs `uv sync --frozen --extra dev`
- make `test` and `ci` depend on `sync-dev` so fresh checkouts bootstrap local tooling
- add a regression test covering the Makefile bootstrap contract

## Verified failure on latest origin/main
- Base commit scanned: `e9a1d3b`
- Fresh detached worktree from `origin/main`: `/private/tmp/codex-daily-bug-scan-repro-20260315-094241`
- `make ci` failed immediately: `uv run mypy src/foliate` -> `error: Failed to spawn: mypy`
- `make test` failed in the same fresh worktree with 16 collection errors because `uv run pytest` fell through to host `pytest` (`Python 3.11.14`) and could not import `foliate`

## Fix evidence
- Commit: `2c0fcb7648f80a9341b032ae5fd3abe1f5508efb`
- Files changed: `Makefile`, `tests/test_makefile.py`
- Diff summary: `15 insertions(+), 3 deletions(-)`

## Validation
- In fresh patched worktree: `make ci` passed
- Results: `uv run mypy src/foliate` succeeded, `uv run pytest -q` passed `398` tests, `uv build` produced sdist and wheel
- Branch worktree verification also passed: `make ci`

## Notes
- Preflight for this automation passed before the scan: DNS resolution for `github.com`, SSH auth to `git@github.com`, and `gh auth status`
